### PR TITLE
Set data_silo title at creation time

### DIFF
--- a/transcend/types/data_silo.go
+++ b/transcend/types/data_silo.go
@@ -39,7 +39,8 @@ type DataSiloUpdatableFields struct {
 }
 
 type CreateDataSilosInput struct {
-	Name graphql.String `json:"name"`
+	Name  graphql.String `json:"name"`
+	Title graphql.String `json:"title"`
 }
 
 type UpdateDataSiloInput struct {
@@ -194,7 +195,8 @@ func GetIntegrationName(d *schema.ResourceData) string {
 
 func CreateDataSiloInput(d *schema.ResourceData) CreateDataSilosInput {
 	return CreateDataSilosInput{
-		Name: graphql.String(GetIntegrationName(d)),
+		Name:  graphql.String(GetIntegrationName(d)),
+		Title: graphql.String(d.Get("title").(string)),
 	}
 }
 


### PR DESCRIPTION
Currently when multiple AWS integrations(Only one I've tested currently) are created, an error is generated due to conflicting titles, as the integration is initially created with the default name of `Amazon Web Services (AWS) - created at 2022-10-18 00:13:03`(With the current date/time) and then renamed separately, which seems to cause a race between the resource update, and the creation of the next integration.

This change passes the title during creation to prevent the race. It seems to mirror existing behavior for integrations created without a title as the api currently(as far as I can tell) treats the lack of a title the same way it treats an empty(`""`) title as they both result in the timestamped integration name

I'm not positive what/if any other implications there may be though.