### PR TITLE
remove schedule_now from plugin options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=transcend.com
 NAMESPACE=cli
 NAME=transcend
 BINARY=terraform-provider-${NAME}
-VERSION=0.9.2
+VERSION=0.10.0
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 

--- a/docs/resources/content_classification_plugin.md
+++ b/docs/resources/content_classification_plugin.md
@@ -23,7 +23,6 @@ description: |-
 
 - `enabled` (Boolean) State to toggle plugin to
 - `schedule_frequency_minutes` (Number) The updated frequency with which we should schedule this plugin, in milliseconds
-- `schedule_now` (Boolean) Whether we should schedule a run immediately after this request
 - `schedule_start_at` (String) The updated start time when we should start scheduling this plugin, in ISO format
 
 ### Read-Only

--- a/docs/resources/data_point_discovery_plugin.md
+++ b/docs/resources/data_point_discovery_plugin.md
@@ -23,7 +23,6 @@ description: |-
 
 - `enabled` (Boolean) State to toggle plugin to
 - `schedule_frequency_minutes` (Number) The updated frequency with which we should schedule this plugin, in milliseconds
-- `schedule_now` (Boolean) Whether we should schedule a run immediately after this request
 - `schedule_start_at` (String) The updated start time when we should start scheduling this plugin, in ISO format
 
 ### Read-Only

--- a/docs/resources/data_silo.md
+++ b/docs/resources/data_silo.md
@@ -310,7 +310,6 @@ resource "transcend_data_silo" "database" {
     enabled                    = true
     schedule_frequency_minutes = 1440 # 1 day
     schedule_start_at          = "2022-09-06T17:51:13.000Z"
-    schedule_now               = false
   }
 
   secret_context {
@@ -347,7 +346,6 @@ resource "transcend_data_silo" "aws" {
     enabled                    = true
     schedule_frequency_minutes = 1440 # 1 day
     schedule_start_at          = "2022-09-06T17:51:13.000Z"
-    schedule_now               = false
   }
 
   # ...other fields...
@@ -371,14 +369,12 @@ resource "transcend_data_silo" "aws" {
     enabled                    = true
     schedule_frequency_minutes = 1440 # 1 day
     schedule_start_at          = "2022-09-06T17:51:13.000Z"
-    schedule_now               = false
   }
 
   content_classification_plugin {
     enabled                    = true
     schedule_frequency_minutes = 1440 # 1 day
     schedule_start_at          = "2022-09-06T17:51:13.000Z"
-    schedule_now               = false
   }
 
   # ...other fields...
@@ -460,7 +456,6 @@ Optional:
 
 - `enabled` (Boolean) State to toggle plugin to
 - `schedule_frequency_minutes` (Number) The updated frequency with which we should schedule this plugin, in milliseconds
-- `schedule_now` (Boolean) Whether we should schedule a run immediately after this request
 - `schedule_start_at` (String) The updated start time when we should start scheduling this plugin, in ISO format
 
 Read-Only:
@@ -476,7 +471,6 @@ Optional:
 
 - `enabled` (Boolean) State to toggle plugin to
 - `schedule_frequency_minutes` (Number) The updated frequency with which we should schedule this plugin, in milliseconds
-- `schedule_now` (Boolean) Whether we should schedule a run immediately after this request
 - `schedule_start_at` (String) The updated start time when we should start scheduling this plugin, in ISO format
 
 Read-Only:
@@ -492,7 +486,6 @@ Optional:
 
 - `enabled` (Boolean) State to toggle plugin to
 - `schedule_frequency_minutes` (Number) The updated frequency with which we should schedule this plugin, in milliseconds
-- `schedule_now` (Boolean) Whether we should schedule a run immediately after this request
 - `schedule_start_at` (String) The updated start time when we should start scheduling this plugin, in ISO format
 
 Read-Only:
@@ -530,7 +523,6 @@ Optional:
 
 - `enabled` (Boolean) State to toggle plugin to
 - `schedule_frequency_minutes` (Number) The updated frequency with which we should schedule this plugin, in milliseconds
-- `schedule_now` (Boolean) Whether we should schedule a run immediately after this request
 - `schedule_start_at` (String) The updated start time when we should start scheduling this plugin, in ISO format
 
 Read-Only:

--- a/docs/resources/data_silo_discovery_plugin.md
+++ b/docs/resources/data_silo_discovery_plugin.md
@@ -46,7 +46,6 @@ resource "transcend_data_silo_discovery_plugin" "plugin" {
   enabled                    = true
   schedule_frequency_minutes = 120
   schedule_start_at          = "2122-09-06T17:51:13.000Z"
-  schedule_now               = false
 
   depends_on = [transcend_data_silo_connection.connection]
 }
@@ -69,7 +68,6 @@ The above example shows how you can use this resource to setup a plugin after a 
 
 - `enabled` (Boolean) State to toggle plugin to
 - `schedule_frequency_minutes` (Number) The updated frequency with which we should schedule this plugin, in milliseconds
-- `schedule_now` (Boolean) Whether we should schedule a run immediately after this request
 - `schedule_start_at` (String) The updated start time when we should start scheduling this plugin, in ISO format
 
 ### Read-Only

--- a/docs/resources/schema_discovery_plugin.md
+++ b/docs/resources/schema_discovery_plugin.md
@@ -23,7 +23,6 @@ description: |-
 
 - `enabled` (Boolean) State to toggle plugin to
 - `schedule_frequency_minutes` (Number) The updated frequency with which we should schedule this plugin, in milliseconds
-- `schedule_now` (Boolean) Whether we should schedule a run immediately after this request
 - `schedule_start_at` (String) The updated start time when we should start scheduling this plugin, in ISO format
 
 ### Read-Only

--- a/examples/api_key/providers.tf
+++ b/examples/api_key/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.9.2"
+      version = "0.10.0"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/data_point/providers.tf
+++ b/examples/data_point/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.9.2"
+      version = "0.10.0"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/data_silo/providers.tf
+++ b/examples/data_silo/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.9.2"
+      version = "0.10.0"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/data_silo/schema_content_plugin.tf
+++ b/examples/data_silo/schema_content_plugin.tf
@@ -6,14 +6,12 @@ resource "transcend_data_silo" "aws" {
     enabled                    = true
     schedule_frequency_minutes = 1440 # 1 day
     schedule_start_at          = "2022-09-06T17:51:13.000Z"
-    schedule_now               = false
   }
 
   content_classification_plugin {
     enabled                    = true
     schedule_frequency_minutes = 1440 # 1 day
     schedule_start_at          = "2022-09-06T17:51:13.000Z"
-    schedule_now               = false
   }
 
   # ...other fields...

--- a/examples/data_silo/silo_plugin.tf
+++ b/examples/data_silo/silo_plugin.tf
@@ -6,7 +6,6 @@ resource "transcend_data_silo" "aws" {
     enabled                    = true
     schedule_frequency_minutes = 1440 # 1 day
     schedule_start_at          = "2022-09-06T17:51:13.000Z"
-    schedule_now               = false
   }
 
   # ...other fields...

--- a/examples/data_silo_plugin/aws_plugin.tf
+++ b/examples/data_silo_plugin/aws_plugin.tf
@@ -30,7 +30,6 @@ resource "transcend_data_silo_discovery_plugin" "plugin" {
   enabled                    = true
   schedule_frequency_minutes = 120
   schedule_start_at          = "2122-09-06T17:51:13.000Z"
-  schedule_now               = false
 
   depends_on = [transcend_data_silo_connection.connection]
 }

--- a/examples/data_silo_plugin/providers.tf
+++ b/examples/data_silo_plugin/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.9.2"
+      version = "0.10.0"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/database_silo/main.tf
+++ b/examples/database_silo/main.tf
@@ -157,7 +157,6 @@ resource "transcend_data_silo" "database" {
     enabled                    = true
     schedule_frequency_minutes = 1440 # 1 day
     schedule_start_at          = "2022-09-06T17:51:13.000Z"
-    schedule_now               = false
   }
 
   secret_context {

--- a/examples/database_silo/providers.tf
+++ b/examples/database_silo/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.9.2"
+      version = "0.10.0"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/tests/api_key/main.tf
+++ b/examples/tests/api_key/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.9.2"
+      version = "0.10.0"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/content_classification_plugin/main.tf
+++ b/examples/tests/content_classification_plugin/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.9.2"
+      version = "0.10.0"
       source  = "transcend.com/cli/transcend"
     }
   }
@@ -17,7 +17,6 @@ variable "plugin_config" {
     enabled                    = bool
     schedule_frequency_minutes = number
     schedule_start_at          = string
-    schedule_now               = bool
   })
 }
 
@@ -48,7 +47,6 @@ resource "transcend_content_classification_plugin" "plugin" {
   enabled                    = var.plugin_config["enabled"]
   schedule_frequency_minutes = var.plugin_config["schedule_frequency_minutes"]
   schedule_start_at          = var.plugin_config["schedule_start_at"]
-  schedule_now               = var.plugin_config["schedule_now"]
 
   depends_on = [transcend_data_silo_connection.connection]
 }

--- a/examples/tests/data_point/main.tf
+++ b/examples/tests/data_point/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.9.2"
+      version = "0.10.0"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/data_point_discovery_plugin/main.tf
+++ b/examples/tests/data_point_discovery_plugin/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.9.2"
+      version = "0.10.0"
       source  = "transcend.com/cli/transcend"
     }
   }
@@ -17,7 +17,6 @@ variable "plugin_config" {
     enabled                    = bool
     schedule_frequency_minutes = number
     schedule_start_at          = string
-    schedule_now               = bool
   })
 }
 
@@ -47,7 +46,6 @@ resource "transcend_data_point_discovery_plugin" "plugin" {
   enabled                    = var.plugin_config["enabled"]
   schedule_frequency_minutes = var.plugin_config["schedule_frequency_minutes"]
   schedule_start_at          = var.plugin_config["schedule_start_at"]
-  schedule_now               = var.plugin_config["schedule_now"]
 
   depends_on = [transcend_data_silo_connection.connection]
 }

--- a/examples/tests/data_silo/main.tf
+++ b/examples/tests/data_silo/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.9.2"
+      version = "0.10.0"
       source  = "transcend.com/cli/transcend"
     }
   }
@@ -57,7 +57,6 @@ variable "schema_discovery_plugin_config" {
     enabled                    = bool
     schedule_frequency_minutes = number
     schedule_start_at          = string
-    schedule_now               = bool
   }))
   default = []
 }
@@ -66,7 +65,6 @@ variable "data_silo_discovery_plugin_config" {
     enabled                    = bool
     schedule_frequency_minutes = number
     schedule_start_at          = string
-    schedule_now               = bool
   }))
   default = []
 }
@@ -75,7 +73,6 @@ variable "content_classification_plugin_config" {
     enabled                    = bool
     schedule_frequency_minutes = number
     schedule_start_at          = string
-    schedule_now               = bool
   }))
   default = []
 }
@@ -97,7 +94,6 @@ resource "transcend_data_silo" "silo" {
       enabled                    = schema_discovery_plugin.value["enabled"]
       schedule_frequency_minutes = schema_discovery_plugin.value["schedule_frequency_minutes"]
       schedule_start_at          = schema_discovery_plugin.value["schedule_start_at"]
-      schedule_now               = schema_discovery_plugin.value["schedule_now"]
     }
   }
 
@@ -107,7 +103,6 @@ resource "transcend_data_silo" "silo" {
       enabled                    = data_silo_discovery_plugin.value["enabled"]
       schedule_frequency_minutes = data_silo_discovery_plugin.value["schedule_frequency_minutes"]
       schedule_start_at          = data_silo_discovery_plugin.value["schedule_start_at"]
-      schedule_now               = data_silo_discovery_plugin.value["schedule_now"]
     }
   }
 
@@ -117,7 +112,6 @@ resource "transcend_data_silo" "silo" {
       enabled                    = content_classification_plugin.value["enabled"]
       schedule_frequency_minutes = content_classification_plugin.value["schedule_frequency_minutes"]
       schedule_start_at          = content_classification_plugin.value["schedule_start_at"]
-      schedule_now               = content_classification_plugin.value["schedule_now"]
     }
   }
 

--- a/examples/tests/data_silo_discovery_plugin/main.tf
+++ b/examples/tests/data_silo_discovery_plugin/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.9.2"
+      version = "0.10.0"
       source  = "transcend.com/cli/transcend"
     }
   }
@@ -17,7 +17,6 @@ variable "plugin_config" {
     enabled                    = bool
     schedule_frequency_minutes = number
     schedule_start_at          = string
-    schedule_now               = bool
   })
 }
 
@@ -47,7 +46,6 @@ resource "transcend_data_silo_discovery_plugin" "plugin" {
   enabled                    = var.plugin_config["enabled"]
   schedule_frequency_minutes = var.plugin_config["schedule_frequency_minutes"]
   schedule_start_at          = var.plugin_config["schedule_start_at"]
-  schedule_now               = var.plugin_config["schedule_now"]
 
   depends_on = [transcend_data_silo_connection.connection]
 }

--- a/examples/tests/enricher/main.tf
+++ b/examples/tests/enricher/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.9.2"
+      version = "0.10.0"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/schema_discovery_plugin/main.tf
+++ b/examples/tests/schema_discovery_plugin/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.9.2"
+      version = "0.10.0"
       source  = "transcend.com/cli/transcend"
     }
   }
@@ -17,7 +17,6 @@ variable "plugin_config" {
     enabled                    = bool
     schedule_frequency_minutes = number
     schedule_start_at          = string
-    schedule_now               = bool
   })
 }
 
@@ -47,7 +46,6 @@ resource "transcend_schema_discovery_plugin" "plugin" {
   enabled                    = var.plugin_config["enabled"]
   schedule_frequency_minutes = var.plugin_config["schedule_frequency_minutes"]
   schedule_start_at          = var.plugin_config["schedule_start_at"]
-  schedule_now               = var.plugin_config["schedule_now"]
 
   depends_on = [transcend_data_silo_connection.connection]
 }

--- a/transcend/resource_content_classification_plugin.go
+++ b/transcend/resource_content_classification_plugin.go
@@ -43,11 +43,6 @@ func resourceContentClassificationPlugin() *schema.Resource {
 				Optional:    true,
 				Description: "The updated start time when we should start scheduling this plugin, in ISO format",
 			},
-			"schedule_now": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Whether we should schedule a run immediately after this request",
-			},
 			"last_enabled_at": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/transcend/resource_content_classification_plugin_test.go
+++ b/transcend/resource_content_classification_plugin_test.go
@@ -41,7 +41,6 @@ func TestCanUseSeparateContentClassificationPluginResource(t *testing.T) {
 			"schedule_frequency_minutes": 120,
 			// Schedule far in the future so that the test works for a long time
 			"schedule_start_at": "2122-09-06T17:51:13.000Z",
-			"schedule_now":      false,
 		},
 	})
 	defer terraform.Destroy(t, options)

--- a/transcend/resource_data_point_discovery_plugin.go
+++ b/transcend/resource_data_point_discovery_plugin.go
@@ -42,11 +42,6 @@ func resourceDataPointDiscoveryPlugin() *schema.Resource {
 				Optional:    true,
 				Description: "The updated start time when we should start scheduling this plugin, in ISO format",
 			},
-			"schedule_now": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Whether we should schedule a run immediately after this request",
-			},
 			"last_enabled_at": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/transcend/resource_data_point_discovery_plugin_test.go
+++ b/transcend/resource_data_point_discovery_plugin_test.go
@@ -41,7 +41,6 @@ func TestCanUseSeparateDataPointDiscoveryPluginResource(t *testing.T) {
 			"schedule_frequency_minutes": 120,
 			// Schedule far in the future so that the test works for a long time
 			"schedule_start_at": "2122-09-06T17:51:13.000Z",
-			"schedule_now":      false,
 		},
 	})
 	defer terraform.Destroy(t, options)

--- a/transcend/resource_data_silo.go
+++ b/transcend/resource_data_silo.go
@@ -150,11 +150,6 @@ func resourceDataSilo() *schema.Resource {
 							Optional:    true,
 							Description: "The updated start time when we should start scheduling this plugin, in ISO format",
 						},
-						"schedule_now": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Description: "Whether we should schedule a run immediately after this request",
-						},
 						"last_enabled_at": {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -190,11 +185,6 @@ func resourceDataSilo() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "The updated start time when we should start scheduling this plugin, in ISO format",
-						},
-						"schedule_now": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Description: "Whether we should schedule a run immediately after this request",
 						},
 						"last_enabled_at": {
 							Type:        schema.TypeString,
@@ -232,11 +222,6 @@ func resourceDataSilo() *schema.Resource {
 							Optional:    true,
 							Description: "The updated start time when we should start scheduling this plugin, in ISO format",
 						},
-						"schedule_now": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Description: "Whether we should schedule a run immediately after this request",
-						},
 						"last_enabled_at": {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -272,11 +257,6 @@ func resourceDataSilo() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "The updated start time when we should start scheduling this plugin, in ISO format",
-						},
-						"schedule_now": {
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Description: "Whether we should schedule a run immediately after this request",
 						},
 						"last_enabled_at": {
 							Type:        schema.TypeString,

--- a/transcend/resource_data_silo_discovery_plugin.go
+++ b/transcend/resource_data_silo_discovery_plugin.go
@@ -42,11 +42,6 @@ func resourceDataSiloDiscoveryPlugin() *schema.Resource {
 				Optional:    true,
 				Description: "The updated start time when we should start scheduling this plugin, in ISO format",
 			},
-			"schedule_now": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Whether we should schedule a run immediately after this request",
-			},
 			"last_enabled_at": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/transcend/resource_data_silo_discovery_plugin_test.go
+++ b/transcend/resource_data_silo_discovery_plugin_test.go
@@ -41,7 +41,6 @@ func TestCanUseSeparateDataSiloDiscoveryPluginResource(t *testing.T) {
 			"schedule_frequency_minutes": 120,
 			// Schedule far in the future so that the test works for a long time
 			"schedule_start_at": "2122-09-06T17:51:13.000Z",
-			"schedule_now":      false,
 		},
 	})
 	defer terraform.Destroy(t, options)

--- a/transcend/resource_data_silo_test.go
+++ b/transcend/resource_data_silo_test.go
@@ -120,7 +120,6 @@ func TestCanConnectSchemaDiscoveryAndContentClassificationPlugin(t *testing.T) {
 				"schedule_frequency_minutes": 120,
 				// Schedule far in the future so that the test works for a long time
 				"schedule_start_at": "2122-09-06T17:51:13.000Z",
-				"schedule_now":      false,
 			},
 		},
 		"content_classification_plugin_config": []map[string]interface{}{
@@ -129,7 +128,6 @@ func TestCanConnectSchemaDiscoveryAndContentClassificationPlugin(t *testing.T) {
 				"schedule_frequency_minutes": 120,
 				// Schedule far in the future so that the test works for a long time
 				"schedule_start_at": "2122-09-06T17:51:13.000Z",
-				"schedule_now":      false,
 			},
 		},
 	})

--- a/transcend/resource_schema_discovery_plugin.go
+++ b/transcend/resource_schema_discovery_plugin.go
@@ -42,11 +42,6 @@ func resourceSchemaDiscoveryPlugin() *schema.Resource {
 				Optional:    true,
 				Description: "The updated start time when we should start scheduling this plugin, in ISO format",
 			},
-			"schedule_now": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Whether we should schedule a run immediately after this request",
-			},
 			"last_enabled_at": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/transcend/resource_schema_discovery_plugin_test.go
+++ b/transcend/resource_schema_discovery_plugin_test.go
@@ -41,7 +41,6 @@ func TestCanUseSeparateSchemaDiscoveryPluginResource(t *testing.T) {
 			"schedule_frequency_minutes": 120,
 			// Schedule far in the future so that the test works for a long time
 			"schedule_start_at": "2122-09-06T17:51:13.000Z",
-			"schedule_now":      false,
 		},
 	})
 	defer terraform.Destroy(t, options)

--- a/transcend/types/data_silo.go
+++ b/transcend/types/data_silo.go
@@ -137,7 +137,7 @@ func MakeStandaloneUpdatePluginInput(d *schema.ResourceData) UpdatePluginInput {
 		Enabled:                  graphql.Boolean(d.Get("enabled").(bool)),
 		ScheduleFrequencyMinutes: graphql.String(strconv.Itoa(d.Get("schedule_frequency_minutes").(int) * 1000 * 60)),
 		ScheduleStartAt:          graphql.String(d.Get("schedule_start_at").(string)),
-		ScheduleNow:              graphql.Boolean(d.Get("schedule_now").(bool)),
+		ScheduleNow:              graphql.Boolean(false),
 	}
 }
 
@@ -148,7 +148,6 @@ func MakeUpdatePluginInput(d *schema.ResourceData, configuration map[string]inte
 		Enabled:                  graphql.Boolean(configuration["enabled"].(bool)),
 		ScheduleFrequencyMinutes: graphql.String(strconv.Itoa(configuration["schedule_frequency_minutes"].(int) * 1000 * 60)),
 		ScheduleStartAt:          graphql.String(configuration["schedule_start_at"].(string)),
-		ScheduleNow:              graphql.Boolean(configuration["schedule_now"].(bool)),
 	}
 }
 


### PR DESCRIPTION
I don't believe this option makes as much sense in Terraform as it does in the UI. As an example...

Say someone creates a silo plugin with schedule_now set to `true`. Later, they update just the `ScheduleFrequencyMinutes` field. Should the plugin re-run immediately? It's a bit unclear, as the initial intent for setting the field to `true` may have been intended as a one-time thing, but Terraform can't really handle that well as a declarative language.

We are seeing non-idempotent applies because of this where setting `schedule_now` to true causes `terraform apply` to show an update every time to that field. That's because `schedule_now` doesn't have a sense of permanence where it could always be true, so we set the value to false when reading state.