### PR TITLE
Prevent destroying already existing data silos on failed updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=transcend.com
 NAMESPACE=cli
 NAME=transcend
 BINARY=terraform-provider-${NAME}
-VERSION=0.12.0
+VERSION=0.13.0
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 

--- a/examples/api_key/providers.tf
+++ b/examples/api_key/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.12.0"
+      version = "0.13.0"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/data_point/providers.tf
+++ b/examples/data_point/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.12.0"
+      version = "0.13.0"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/data_silo/providers.tf
+++ b/examples/data_silo/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.12.0"
+      version = "0.13.0"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/data_silo_plugin/providers.tf
+++ b/examples/data_silo_plugin/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.12.0"
+      version = "0.13.0"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/database_silo/providers.tf
+++ b/examples/database_silo/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.12.0"
+      version = "0.13.0"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/tests/api_key/main.tf
+++ b/examples/tests/api_key/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.12.0"
+      version = "0.13.0"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/content_classification_plugin/main.tf
+++ b/examples/tests/content_classification_plugin/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.12.0"
+      version = "0.13.0"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/data_point/main.tf
+++ b/examples/tests/data_point/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.12.0"
+      version = "0.13.0"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/data_silo/main.tf
+++ b/examples/tests/data_silo/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.12.0"
+      version = "0.13.0"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/data_silo_discovery_plugin/main.tf
+++ b/examples/tests/data_silo_discovery_plugin/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.12.0"
+      version = "0.13.0"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/enricher/main.tf
+++ b/examples/tests/enricher/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.12.0"
+      version = "0.13.0"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/schema_discovery_plugin/main.tf
+++ b/examples/tests/schema_discovery_plugin/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.12.0"
+      version = "0.13.0"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/transcend/resource_data_silo.go
+++ b/transcend/resource_data_silo.go
@@ -473,9 +473,11 @@ func resourceDataSilosUpdate(ctx context.Context, d *schema.ResourceData, m inte
 			Summary:  "Error updating data silos",
 			Detail:   "Error when updating data silo: " + err.Error(),
 		})
-		deletionDiags := resourceDataSilosDelete(ctx, d, m)
-		if deletionDiags.HasError() {
-			diags = append(diags, deletionDiags...)
+		if d.IsNewResource() {
+			deletionDiags := resourceDataSilosDelete(ctx, d, m)
+			if deletionDiags.HasError() {
+				diags = append(diags, deletionDiags...)
+			}
 		}
 		return diags
 	}
@@ -500,9 +502,11 @@ func resourceDataSilosUpdate(ctx context.Context, d *schema.ResourceData, m inte
 				Summary:  "Error Finding sombra URL",
 				Detail:   "Error when updating data silo: " + err.Error(),
 			})
-			deletionDiags := resourceDataSilosDelete(ctx, d, m)
-			if deletionDiags.HasError() {
-				diags = append(diags, deletionDiags...)
+			if d.IsNewResource() {
+				deletionDiags := resourceDataSilosDelete(ctx, d, m)
+				if deletionDiags.HasError() {
+					diags = append(diags, deletionDiags...)
+				}
 			}
 			return diags
 		}
@@ -521,9 +525,11 @@ func resourceDataSilosUpdate(ctx context.Context, d *schema.ResourceData, m inte
 				Summary:  "Error Finding saas context metadata",
 				Detail:   "Error when updating data silo: " + err.Error(),
 			})
-			deletionDiags := resourceDataSilosDelete(ctx, d, m)
-			if deletionDiags.HasError() {
-				diags = append(diags, deletionDiags...)
+			if d.IsNewResource() {
+				deletionDiags := resourceDataSilosDelete(ctx, d, m)
+				if deletionDiags.HasError() {
+					diags = append(diags, deletionDiags...)
+				}
 			}
 			return diags
 		}
@@ -536,9 +542,11 @@ func resourceDataSilosUpdate(ctx context.Context, d *schema.ResourceData, m inte
 				Summary:  "Error encoding secret map to create saas context",
 				Detail:   "Error when updating data silo: " + err.Error(),
 			})
-			deletionDiags := resourceDataSilosDelete(ctx, d, m)
-			if deletionDiags.HasError() {
-				diags = append(diags, deletionDiags...)
+			if d.IsNewResource() {
+				deletionDiags := resourceDataSilosDelete(ctx, d, m)
+				if deletionDiags.HasError() {
+					diags = append(diags, deletionDiags...)
+				}
 			}
 			return diags
 		}
@@ -549,9 +557,11 @@ func resourceDataSilosUpdate(ctx context.Context, d *schema.ResourceData, m inte
 				Summary:  "Error constructing sombra url for the register saas route",
 				Detail:   "Details: " + err.Error(),
 			})
-			deletionDiags := resourceDataSilosDelete(ctx, d, m)
-			if deletionDiags.HasError() {
-				diags = append(diags, deletionDiags...)
+			if d.IsNewResource() {
+				deletionDiags := resourceDataSilosDelete(ctx, d, m)
+				if deletionDiags.HasError() {
+					diags = append(diags, deletionDiags...)
+				}
 			}
 			return diags
 		}
@@ -562,9 +572,11 @@ func resourceDataSilosUpdate(ctx context.Context, d *schema.ResourceData, m inte
 				Summary:  "Error creating SaaS context for the secret values",
 				Detail:   "Error when updating data silo: " + err.Error(),
 			})
-			deletionDiags := resourceDataSilosDelete(ctx, d, m)
-			if deletionDiags.HasError() {
-				diags = append(diags, deletionDiags...)
+			if d.IsNewResource() {
+				deletionDiags := resourceDataSilosDelete(ctx, d, m)
+				if deletionDiags.HasError() {
+					diags = append(diags, deletionDiags...)
+				}
 			}
 			return diags
 		}
@@ -575,9 +587,11 @@ func resourceDataSilosUpdate(ctx context.Context, d *schema.ResourceData, m inte
 				Summary:  "Error reading response of the new SaaS context",
 				Detail:   "Error when updating data silo: " + err.Error(),
 			})
-			deletionDiags := resourceDataSilosDelete(ctx, d, m)
-			if deletionDiags.HasError() {
-				diags = append(diags, deletionDiags...)
+			if d.IsNewResource() {
+				deletionDiags := resourceDataSilosDelete(ctx, d, m)
+				if deletionDiags.HasError() {
+					diags = append(diags, deletionDiags...)
+				}
 			}
 			return diags
 		}
@@ -587,9 +601,11 @@ func resourceDataSilosUpdate(ctx context.Context, d *schema.ResourceData, m inte
 				Summary:  "Error creating a new SaaS context",
 				Detail:   string(saasContext),
 			})
-			deletionDiags := resourceDataSilosDelete(ctx, d, m)
-			if deletionDiags.HasError() {
-				diags = append(diags, deletionDiags...)
+			if d.IsNewResource() {
+				deletionDiags := resourceDataSilosDelete(ctx, d, m)
+				if deletionDiags.HasError() {
+					diags = append(diags, deletionDiags...)
+				}
 			}
 			return diags
 		}
@@ -614,9 +630,11 @@ func resourceDataSilosUpdate(ctx context.Context, d *schema.ResourceData, m inte
 				Summary:  "Error connecting data silos",
 				Detail:   "Error when connecting data silo: " + err.Error(),
 			})
-			deletionDiags := resourceDataSilosDelete(ctx, d, m)
-			if deletionDiags.HasError() {
-				diags = append(diags, deletionDiags...)
+			if d.IsNewResource() {
+				deletionDiags := resourceDataSilosDelete(ctx, d, m)
+				if deletionDiags.HasError() {
+					diags = append(diags, deletionDiags...)
+				}
 			}
 			return diags
 		}


### PR DESCRIPTION
If a silo exists already and any update to that silo fails, we should not delete that silo, but just exit with an error message in whatever state the silo is left in.