### PR TITLE
Use bulk gql endpoint for resourceDataSilosUpdate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=transcend.com
 NAMESPACE=cli
 NAME=transcend
 BINARY=terraform-provider-${NAME}
-VERSION=0.14.0
+VERSION=0.15.0
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 

--- a/examples/api_key/providers.tf
+++ b/examples/api_key/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.14.0"
+      version = "0.15.0"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/data_point/providers.tf
+++ b/examples/data_point/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.14.0"
+      version = "0.15.0"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/data_silo/providers.tf
+++ b/examples/data_silo/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.14.0"
+      version = "0.15.0"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/data_silo_plugin/providers.tf
+++ b/examples/data_silo_plugin/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.14.0"
+      version = "0.15.0"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/database_silo/providers.tf
+++ b/examples/database_silo/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.14.0"
+      version = "0.15.0"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/tests/api_key/main.tf
+++ b/examples/tests/api_key/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.14.0"
+      version = "0.15.0"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/content_classification_plugin/main.tf
+++ b/examples/tests/content_classification_plugin/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.14.0"
+      version = "0.15.0"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/data_point/main.tf
+++ b/examples/tests/data_point/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.14.0"
+      version = "0.15.0"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/data_silo/main.tf
+++ b/examples/tests/data_silo/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.14.0"
+      version = "0.15.0"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/data_silo_discovery_plugin/main.tf
+++ b/examples/tests/data_silo_discovery_plugin/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.14.0"
+      version = "0.15.0"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/enricher/main.tf
+++ b/examples/tests/enricher/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.14.0"
+      version = "0.15.0"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/schema_discovery_plugin/main.tf
+++ b/examples/tests/schema_discovery_plugin/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.14.0"
+      version = "0.15.0"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/transcend/resource_data_silo.go
+++ b/transcend/resource_data_silo.go
@@ -461,9 +461,9 @@ func resourceDataSilosUpdate(ctx context.Context, d *schema.ResourceData, m inte
 
 	// Perform updates to most fields on the data silo
 	var updateMutation struct {
-		UpdateDataSilo struct {
-			DataSilo types.DataSilo
-		} `graphql:"updateDataSilo(input: $input)"`
+		UpdateDataSilos struct {
+			DataSilos []types.DataSilo
+		} `graphql:"updateDataSilos(input: { dataSilos: [$input] })"`
 	}
 	updateVars := map[string]interface{}{
 		"input": types.UpdateDataSiloInput{
@@ -471,7 +471,7 @@ func resourceDataSilosUpdate(ctx context.Context, d *schema.ResourceData, m inte
 			DataSiloUpdatableFields: types.CreateDataSiloUpdatableFields(d),
 		},
 	}
-	err := client.graphql.Mutate(context.Background(), &updateMutation, updateVars, graphql.OperationName("UpdateDataSilo"))
+	err := client.graphql.Mutate(context.Background(), &updateMutation, updateVars, graphql.OperationName("UpdateDataSilos"))
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,


### PR DESCRIPTION
- Links https://transcend.height.app/T-20840 

Update `resourceDataSilosUpdate` to use the bulk GQL endpoint, `updateDataSilos`. The old GQL update, `updateDataSilo` has been deprecated and will be removed. All usage of `terraform-provider-transcend` should be updated to the latest version to avoid errors.
