### PR TITLE
Reduce frequent diffs when specifying owners of data silos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=transcend.com
 NAMESPACE=cli
 NAME=transcend
 BINARY=terraform-provider-${NAME}
-VERSION=0.18.15
+VERSION=0.18.16
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 

--- a/examples/api_key/providers.tf
+++ b/examples/api_key/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.15"
+      version = "0.18.16"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/data_point/providers.tf
+++ b/examples/data_point/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.15"
+      version = "0.18.16"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/data_silo/providers.tf
+++ b/examples/data_silo/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.15"
+      version = "0.18.16"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/data_silo_plugin/providers.tf
+++ b/examples/data_silo_plugin/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.15"
+      version = "0.18.16"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/database_silo/providers.tf
+++ b/examples/database_silo/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.15"
+      version = "0.18.16"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/tests/api_key/main.tf
+++ b/examples/tests/api_key/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.15"
+      version = "0.18.16"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/content_classification_plugin/main.tf
+++ b/examples/tests/content_classification_plugin/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.15"
+      version = "0.18.16"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/data_point/main.tf
+++ b/examples/tests/data_point/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.15"
+      version = "0.18.16"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/data_silo/main.tf
+++ b/examples/tests/data_silo/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.15"
+      version = "0.18.16"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/data_silo_data_source/main.tf
+++ b/examples/tests/data_silo_data_source/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.15"
+      version = "0.18.16"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/data_silo_discovery_plugin/main.tf
+++ b/examples/tests/data_silo_discovery_plugin/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.15"
+      version = "0.18.16"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/enricher/main.tf
+++ b/examples/tests/enricher/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.15"
+      version = "0.18.16"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/schema_discovery_plugin/main.tf
+++ b/examples/tests/schema_discovery_plugin/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.15"
+      version = "0.18.16"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/transcend/resource_data_silo.go
+++ b/transcend/resource_data_silo.go
@@ -350,7 +350,7 @@ func resourceDataSilo() *schema.Resource {
 			// 	Description: "The list of subject IDs to block list from this data silo",
 			// },
 			"owner_emails": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -358,7 +358,7 @@ func resourceDataSilo() *schema.Resource {
 				Description: "The emails of the users to assign as owners of this data silo. These emails must have matching users on Transcend.",
 			},
 			"owner_teams": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,


### PR DESCRIPTION
This pull request includes updates to the Transcend Terraform provider, primarily focusing on upgrading the provider version across multiple files and improving the handling of owner emails and teams in the `resource_data_silo.go` implementation. Additionally, new test cases and helper functions have been added to ensure the robustness of the changes.

### Provider Version Upgrade:
* Updated the provider version from `0.18.15` to `0.18.16` in `Makefile` and multiple `providers.tf` files across examples and tests. This ensures compatibility with the latest version of the Transcend provider. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L6-R6) [[2]](diffhunk://#diff-5093aaca7aafef740239a4534fcd397aa738cd23b5a233add8ebce8d8831af58L4-R4) [[3]](diffhunk://#diff-dd9e738993a81287c3c1b1bfd8f64dc3f04c89ca9fe702adfee34e0795388618L4-R4) [[4]](diffhunk://#diff-238d06dd228db733134cd1d923099cf778fa585a3a707471ce8c1c907145c9e0L4-R4) [[5]](diffhunk://#diff-0811492641b704be9c64b8f5f373e8a19d9c4e2fbe22c0c9eed07408f141d240L4-R4) [[6]](diffhunk://#diff-544a08c61c063b9320b9088449c2bcfd8f5231f64cadb39465b8b7b1f53144b1L4-R4) [[7]](diffhunk://#diff-3eac5f232fbfc155a4e99cf5441378034e9c7c60a4ad086d864495c00e57f322L4-R4) [[8]](diffhunk://#diff-55cb21be8d984db97a997c0e88d39a048b9e65ff967c0177f96f1e4e009e8f2eL4-R4) [[9]](diffhunk://#diff-db10a93c60b424c803d2ac7bbddc310cb6c31b404be179cd4e0bd11bb3332cc6L4-R4) [[10]](diffhunk://#diff-b72eb164cc3a7df1a22b85276d1a5f25e8601a13f1cdace9d6bb03a4f8bbaeafL4-R4) [[11]](diffhunk://#diff-a7c8c2d9ef51952f51877426e7651be26a1321a2e8c8c020f9f6753d3d2dd70cL4-R4) [[12]](diffhunk://#diff-3f9625f226ba27ed05ab223eb954c350d387b5ddc485044dc6018ce173f00b49L4-R4)

### Improved Data Silo Resource Handling:
* Changed `owner_emails` and `owner_teams` attributes from `schema.TypeList` to `schema.TypeSet` in `resource_data_silo.go` to ensure order independence and eliminate duplicates.
* Enhanced the `CreateDataSiloUpdatableFields` function to sort and convert `owner_emails` and `owner_teams` into GraphQL-compatible formats, ensuring consistent state representation.
* Modified the `FlattenOwners` and `FlattenOwnerTeams` functions to sort the output, ensuring state order independence for owners and teams.

### New Test Cases and Helper Functions:
* Added the `destroyDataSiloByTitle` helper function to clean up silos before tests, ensuring test isolation.
* Introduced the `TestOwnerEmailsOrderIndependence` test case to verify that `owner_emails` remain consistent in state regardless of input order.

### Codebase Enhancements:
* Added sorting functionality to the `types/data_silo.go` file to support the new handling of `owner_emails` and `owner_teams`.

These changes collectively improve the reliability and maintainability of the Transcend Terraform provider, ensuring compatibility with the latest version and enhancing the handling of data silo ownership attributes.