### PR TITLE
Allow user to specify a custom internal sombra URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=transcend.com
 NAMESPACE=cli
 NAME=transcend
 BINARY=terraform-provider-${NAME}
-VERSION=0.18.16
+VERSION=0.18.17
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 

--- a/examples/api_key/providers.tf
+++ b/examples/api_key/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.16"
+      version = "0.18.17"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/data_point/providers.tf
+++ b/examples/data_point/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.16"
+      version = "0.18.17"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/data_silo/providers.tf
+++ b/examples/data_silo/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.16"
+      version = "0.18.17"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/data_silo_plugin/providers.tf
+++ b/examples/data_silo_plugin/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.16"
+      version = "0.18.17"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/database_silo/providers.tf
+++ b/examples/database_silo/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.16"
+      version = "0.18.17"
       source  = "transcend.com/cli/transcend"
     }
     aws = {

--- a/examples/tests/api_key/main.tf
+++ b/examples/tests/api_key/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.16"
+      version = "0.18.17"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/content_classification_plugin/main.tf
+++ b/examples/tests/content_classification_plugin/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.16"
+      version = "0.18.17"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/data_point/main.tf
+++ b/examples/tests/data_point/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.16"
+      version = "0.18.17"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/data_silo/main.tf
+++ b/examples/tests/data_silo/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.16"
+      version = "0.18.17"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/data_silo_data_source/main.tf
+++ b/examples/tests/data_silo_data_source/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.16"
+      version = "0.18.17"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/data_silo_discovery_plugin/main.tf
+++ b/examples/tests/data_silo_discovery_plugin/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.16"
+      version = "0.18.17"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/enricher/main.tf
+++ b/examples/tests/enricher/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.16"
+      version = "0.18.17"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/examples/tests/schema_discovery_plugin/main.tf
+++ b/examples/tests/schema_discovery_plugin/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     transcend = {
-      version = "0.18.16"
+      version = "0.18.17"
       source  = "transcend.com/cli/transcend"
     }
   }

--- a/transcend/client.go
+++ b/transcend/client.go
@@ -28,19 +28,27 @@ func (t *sombraTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return http.DefaultTransport.RoundTrip(req)
 }
 
+
 type Client struct {
-	graphql      *graphql.Client
-	sombraClient *http.Client
-	url          string
+   graphql         *graphql.Client
+   sombraClient    *http.Client
+   url             string
+   internalSombraUrl string
 }
 
-func NewClient(url, apiToken string, internalKey string) *Client {
-	backendClient := &http.Client{Transport: &backendTransport{apiToken: apiToken}}
-	sombraClient := &http.Client{Transport: &sombraTransport{apiToken: apiToken, internalKey: internalKey}}
 
-	return &Client{
-		graphql:      graphql.NewClient(url, backendClient),
-		sombraClient: sombraClient,
-		url:          url,
-	}
+func NewClient(url, apiToken string, internalKey string) *Client {
+   return NewClientWithSombraUrl(url, apiToken, internalKey, "")
+}
+
+func NewClientWithSombraUrl(url, apiToken string, internalKey string, internalSombraUrl string) *Client {
+   backendClient := &http.Client{Transport: &backendTransport{apiToken: apiToken}}
+   sombraClient := &http.Client{Transport: &sombraTransport{apiToken: apiToken, internalKey: internalKey}}
+
+   return &Client{
+	   graphql:      graphql.NewClient(url, backendClient),
+	   sombraClient: sombraClient,
+	   url:          url,
+	   internalSombraUrl: internalSombraUrl,
+   }
 }

--- a/transcend/provider.go
+++ b/transcend/provider.go
@@ -11,26 +11,32 @@ import (
 // Provider -
 func Provider() *schema.Provider {
 	return &schema.Provider{
-		Schema: map[string]*schema.Schema{
-			"url": {
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TRANSCEND_URL", "https://api.transcend.io/"),
-				Description: "The custom Transcend backend URL to talk to. Typically can be left to the default production URL.",
-			},
-			"key": {
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TRANSCEND_KEY", nil),
-				Description: "The API Key to use to talk to Transcend. Ensure it has the scopes to perform whatever actions you need. Can be set using the TRANSCEND_KEY environment variable.",
-			},
-			"internal_sombra_key": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TRANSCEND_INTERNAL_SOMBRA_KEY", nil),
-				Description: "The API Key to use to talk to a self-hosted sombra. Only used for enterprises with the self-hosted option",
-			},
-		},
+	   Schema: map[string]*schema.Schema{
+		   "url": {
+			   Type:        schema.TypeString,
+			   Required:    true,
+			   DefaultFunc: schema.EnvDefaultFunc("TRANSCEND_URL", "https://api.transcend.io/"),
+			   Description: "The custom Transcend backend URL to talk to. Typically can be left to the default production URL.",
+		   },
+		   "key": {
+			   Type:        schema.TypeString,
+			   Required:    true,
+			   DefaultFunc: schema.EnvDefaultFunc("TRANSCEND_KEY", nil),
+			   Description: "The API Key to use to talk to Transcend. Ensure it has the scopes to perform whatever actions you need. Can be set using the TRANSCEND_KEY environment variable.",
+		   },
+		   "internal_sombra_key": {
+			   Type:        schema.TypeString,
+			   Optional:    true,
+			   DefaultFunc: schema.EnvDefaultFunc("TRANSCEND_INTERNAL_SOMBRA_KEY", nil),
+			   Description: "The API Key to use to talk to a self-hosted sombra. Only used for enterprises with the self-hosted option",
+		   },
+		   "internal_sombra_url": {
+			   Type:        schema.TypeString,
+			   Optional:    true,
+			   DefaultFunc: schema.EnvDefaultFunc("TRANSCEND_INTERNAL_SOMBRA_URL", nil),
+			   Description: "If set, this URL will be used for sombra operations instead of querying the backend. Useful for reverse proxy instances.",
+		   },
+	   },
 		ResourcesMap: map[string]*schema.Resource{
 			"transcend_api_key":                       resourceAPIKey(),
 			"transcend_data_point":                    resourceDataPoint(),
@@ -52,9 +58,10 @@ func Provider() *schema.Provider {
 }
 
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-	backendUrl := d.Get("url").(string)
-	backendApiKey := d.Get("key").(string)
-	sombraInternalKey := d.Get("internal_sombra_key").(string)
+   backendUrl := d.Get("url").(string)
+   backendApiKey := d.Get("key").(string)
+   sombraInternalKey := d.Get("internal_sombra_key").(string)
+   internalSombraUrl := d.Get("internal_sombra_url").(string)
 
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
@@ -78,5 +85,5 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		return nil, diags
 	}
 
-	return NewClient(graphQlUrl, backendApiKey, sombraInternalKey), nil
+   return NewClientWithSombraUrl(graphQlUrl, backendApiKey, sombraInternalKey, internalSombraUrl), nil
 }


### PR DESCRIPTION
Adds a new `internal_sombra_url` to the provider. For reverse proxy setups, the `publicUrl` in our db will often point at just the piko cluster, and we're moving away from our backend knowing about the internal URL at all. This lets a customer choose to specify a URL if they want, otherwise the provider will still be able to query for the url of the primary sombra of the org their API key belongs to, as we had before